### PR TITLE
Remove version from main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.16.0"
     }
   }
 }


### PR DESCRIPTION
The version of this package causes significant headaches when trying to run a terraform init on MBP darwin_x64 architecture. 

Considering the repository that is to be cloned in the previous step does not specify the version, it should be okay to remove the version from this file too. After spending hours trying to figure what the issue was, I discovered that it is because of the aforementioned.

Please see the main.tf in this repository as an example, as you can see there is no hashicorp/aws version specified thus no issues are occurring on darwin_x64 architecture MBPs.

https://github.com/hashicorp/learn-terraform-variables