### PR TITLE
relax Terraform core version constraint

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -18,5 +18,5 @@ terraform {
     }
   }
 
-  required_version = "~> 1.2.0"
+  required_version = "~> 1.2"
 }


### PR DESCRIPTION
Currently, the Terraform version constraint limits the users to Terraform `1.2.x` which is already somewhat outdated. 

Updating the constraint to `~> 1.2` will allow the users to have any `1.x` version which should still be safe.