### PR TITLE
Fix main.tf with engine_version "5.7" and instance_class "db.t3.miro"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,8 @@ resource "aws_db_subnet_group" "private" {
 resource "aws_db_instance" "database" {
   allocated_storage = 5
   engine            = "mysql"
-  instance_class    = "db.t2.micro"
+  engine_version    = "5.7"
+  instance_class    = "db.t3.micro"
   username          = var.db_username
   password          = var.db_password
 


### PR DESCRIPTION
Fixes RDS incompatibility issue which produces the below error in the current repo

│ Error: creating RDS DB Instance (terraform-20240325081656813800000004): InvalidParameterCombination: RDS does not support creating a DB instance with the following combination: DBInstanceClass=db.t2.micro, Engine=mysql, EngineVersion=8.0.35, LicenseModel=general-public-license. For supported combinations of instance class and database engine version, see the documentation.
│       status code: 400, request id: 9eddb874-accf-4a49-a851-eec4234470e5
│ 
│   with aws_db_instance.database,
│   on main.tf line 97, in resource "aws_db_instance" "database":
│   97: resource "aws_db_instance" "database" {
│ 